### PR TITLE
Allocations optimisations

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -13,9 +13,27 @@ var (
 	flagRegex = regexp.MustCompile(`^:flag-([a-zA-Z]{2}):$`)
 )
 
+type Parser struct {
+	matched bytes.Buffer
+}
+
+func NewParser() *Parser {
+	return &Parser{matched: bytes.Buffer{}}
+}
+
+// Parse replaces emoji aliases (:pizza:) with unicode representation.
+func (p *Parser) Parse(input string) string {
+	p.matched.Reset()
+	return parseInternal(input, &p.matched)
+}
+
 // Parse replaces emoji aliases (:pizza:) with unicode representation.
 func Parse(input string) string {
-	matched := &bytes.Buffer{}
+	return parseInternal(input, &bytes.Buffer{})
+}
+
+// Parse replaces emoji aliases (:pizza:) with unicode representation.
+func parseInternal(input string, matched *bytes.Buffer) string {
 	var output strings.Builder
 	output.Grow(len(input))
 

--- a/parser.go
+++ b/parser.go
@@ -17,6 +17,7 @@ var (
 func Parse(input string) string {
 	matched := &bytes.Buffer{}
 	var output strings.Builder
+	output.Grow(len(input))
 
 	for _, r := range input {
 		// when it's not `:`, it might be inner or outer of the emoji alias

--- a/parser.go
+++ b/parser.go
@@ -45,7 +45,8 @@ func Parse(input string) string {
 
 		// it's the end of the emoji alias
 		match := matched.String()
-		alias := match + ":"
+		matched.WriteByte(':')
+		alias := matched.String()
 
 		// check for emoji alias
 		if code, ok := Find(alias); ok {
@@ -59,7 +60,6 @@ func Parse(input string) string {
 		// it might be the beginning of the another emoji alias
 		matched.Reset()
 		matched.WriteRune(r)
-
 	}
 
 	// if matched not empty, add it to output

--- a/parser_test.go
+++ b/parser_test.go
@@ -163,9 +163,19 @@ func TestFind(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
-	b.ReportAllocs()
+	b.Run("static", func(b *testing.B) {
+		b.ReportAllocs()
 
-	for n := 0; n < b.N; n++ {
-		_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
-	}
+		for n := 0; n < b.N; n++ {
+			_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+		}
+	})
+
+	b.Run("reusable", func(b *testing.B) {
+		b.ReportAllocs()
+		p := NewParser()
+		for n := 0; n < b.N; n++ {
+			_ = p.Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
+		}
+	})
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -69,10 +69,13 @@ func TestParse(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		got := Parse(tc.input)
-		if got != tc.expected {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
-		}
+		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
+			got := Parse(tc.input)
+
+			if got != tc.expected {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
+			}
+		})
 	}
 }
 
@@ -146,14 +149,16 @@ func TestFind(t *testing.T) {
 	}
 
 	for i, tc := range tt {
-		got, exist := Find(tc.input)
-		if got != tc.expected {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
-		}
+		t.Run(fmt.Sprintf("test #%d", i), func(t *testing.T) {
+			got, exist := Find(tc.input)
+			if got != tc.expected {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, got, tc.expected)
+			}
 
-		if exist != tc.exist {
-			t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, exist, tc.exist)
-		}
+			if exist != tc.exist {
+				t.Fatalf("test case %v fail: got: %v, expected: %v", i+1, exist, tc.exist)
+			}
+		})
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -158,6 +158,8 @@ func TestFind(t *testing.T) {
 }
 
 func BenchmarkParse(b *testing.B) {
+	b.ReportAllocs()
+
 	for n := 0; n < b.N; n++ {
 		_ = Parse("I am :man_technologist: from :flag_for_turkey:. Tests are :thumbs_up:")
 	}


### PR DESCRIPTION
A set of optimisations related to allocations

```
Original
BenchmarkParse
BenchmarkParse-12    	 1446430	       799.4 ns/op	     288 B/op	      14 allocs/op

Remove redundant allocation
BenchmarkParse
BenchmarkParse-12    	 1482784	       719.3 ns/op	     256 B/op	      12 allocs/op

Use bytes.Buffer for matched
BenchmarkParse
BenchmarkParse-12    	 1745038	       638.7 ns/op	     184 B/op	       5 allocs/op

Preallocate required space
BenchmarkParse/static
BenchmarkParse/static-12         	 2146411	       536.6 ns/op	     144 B/op	       2 allocs/op

Reusable parser
BenchmarkParse/reusable
BenchmarkParse/reusable-12       	 2438487	       494.8 ns/op	      80 B/op	       1 allocs/op
```